### PR TITLE
Replace manual 64-bit popcount with __builtin_popcountll

### DIFF
--- a/include/kitty/bit_operations.hpp
+++ b/include/kitty/bit_operations.hpp
@@ -344,7 +344,7 @@ inline uint64_t count_ones( const TT& tt )
   return std::accumulate( tt.cbegin(), tt.cend(), uint64_t( 0 ),
                           []( auto accu, auto word )
                           {
-                            return accu + __builtin_popcount( word & 0xffffffff ) + __builtin_popcount( word >> 32 );
+                            return accu + __builtin_popcountll( word );
                           } );
 }
 
@@ -352,7 +352,7 @@ inline uint64_t count_ones( const TT& tt )
 template<uint32_t NumVars>
 inline uint64_t count_ones( const static_truth_table<NumVars, true>& tt )
 {
-  return __builtin_popcount( tt._bits & 0xffffffff ) + __builtin_popcount( tt._bits >> 32 );
+  return __builtin_popcountll( tt._bits );
 }
 /*! \endcond */
 

--- a/include/kitty/detail/mscfix.hpp
+++ b/include/kitty/detail/mscfix.hpp
@@ -36,4 +36,5 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 #define __builtin_popcount __popcnt
+#define __builtin_popcountll __popcnt64
 #endif


### PR DESCRIPTION
This PR replaces the previous manual method of counting set bits in `uint64_t` values (which used two 32-bit popcount operations) with `__builtin_popcountll` to target compilation to a single hardware instruction.