### PR TITLE
SIMD Acceleration of Truth-Table Operations with AVX2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,16 @@ if (HAS_FCOLOR_DIAGNOSTICS)
   add_compile_options(-fcolor-diagnostics)
 endif()
 
+# compiler options for SIMD operations
+if(MSVC)
+  add_compile_options(/arch:AVX2)
+elseif(UNIX)
+  check_cxx_compiler_flag("-mavx2" HAS_MAVX2)
+  if(HAS_MAVX2)
+    add_compile_options(-mavx2)
+  endif()
+endif()
+
 if (UNIX)
   add_compile_options(-W -Wall)
 else()

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1103,7 +1103,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML          = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Next release
 ------------
 
 * SIMD operations: header ``simd_operations`` (contributed by Andrea Costamagna)
-  `#133 <https://github.com/msoeken/kitty/pull/142>`_
+  `#142 <https://github.com/msoeken/kitty/pull/142>`_
 
 v0.8 (September 9, 2022)
 ------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@ Change Log
 Next release
 ------------
 
+* SIMD operations: header ``simd_operations`` (contributed by Andrea Costamagna)
+  `#133 <https://github.com/msoeken/kitty/pull/142>`_
+
 v0.8 (September 9, 2022)
 ------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Welcome to kitty's documentation!
 
    truth_table_data_structures
    bit_operations
+   simd_operations
    algorithm
    constructors
    operations

--- a/docs/simd_operations.rst
+++ b/docs/simd_operations.rst
@@ -1,9 +1,6 @@
 Single Instruction Multiple Data Operations
 ===========================================
 
-Dynamic truth table
--------------------
-
 The header ``<kitty/simd_operations.hpp>`` implements bitwise operations
 that are optimized through vectorization, if supported by the machine on
 which the code is compiled. It is suggested to replace the traditional 

--- a/docs/simd_operations.rst
+++ b/docs/simd_operations.rst
@@ -1,0 +1,23 @@
+Single Instruction Multiple Data Operations
+===========================================
+
+Dynamic truth table
+-------------------
+
+The header ``<kitty/simd_operations.hpp>`` implements bitwise operations
+that are optimized through vectorization, if supported by the machine on
+which the code is compiled. It is suggested to replace the traditional 
+operations with these alternatives for truth table with more than `1024`
+bits. However, compiler dependent profiling is required to identify the
+performance cutoff.
+
+The header provides the following functions:
+
+.. doc_brief_table::
+   simd::bitwise_and
+   simd::bitwise_or
+   simd::bitwise_xor
+   simd::bitwise_lt
+   simd::unary_not
+   simd::set_zero
+   simd::set_ones

--- a/include/kitty/kitty.hpp
+++ b/include/kitty/kitty.hpp
@@ -55,6 +55,7 @@
 #include "permutation.hpp"
 #include "print.hpp"
 #include "properties.hpp"
+#include "simd_operations.hpp"
 #include "spectral.hpp"
 #include "spp.hpp"
 #include "traits.hpp"

--- a/include/kitty/simd_operations.hpp
+++ b/include/kitty/simd_operations.hpp
@@ -386,8 +386,8 @@ inline void set_ones( TT& tt )
 
 class benchmarking
 {
-  static constexpr auto num_cases = 20u;
-  static constexpr double eps = 0.05;
+  static constexpr auto num_cases = 100u;
+  static constexpr double eps = 0.1;
   bool const has_avx2 = has_avx2_cached();
 public:
   template<typename FnSisd, typename FnSimd, typename TT>

--- a/include/kitty/simd_operations.hpp
+++ b/include/kitty/simd_operations.hpp
@@ -25,7 +25,7 @@
 
 /*!
   \file simd_operations.hpp
-  \brief Implements efficient alternatives of some common operations using SIMD
+  \brief Implements efficient alternatives of common truth-table operations.
 
   \author Andrea Costamagna
 */
@@ -36,6 +36,7 @@
 #include <cassert>
 #include <numeric>
 #include <algorithm>
+#include <functional>
 
 #include "static_truth_table.hpp"
 #include "partial_truth_table.hpp"
@@ -97,7 +98,7 @@ inline bool has_avx2_cached()
 #endif
 }
 
-/*! Enumeration type to minimize code redundancies. */
+/*! \brief Enumeration for compile-time dispatch and minimize code redundancies. */
 enum class BinaryOp
 {
   AND,
@@ -106,51 +107,81 @@ enum class BinaryOp
   LT
 };
 
-/*! Compile-time dispatch of the binary operations. */
+/*! Compile-time dispatch of the vector operations. */
 #if KITTY_HAS_AVX2
-template<BinaryOp binary_op>
-inline __m256i get_simd_op( __m256i vr, __m256i v2 )
+template<BinaryOp Op>
+constexpr auto vector_operation()
 {
-  if constexpr ( binary_op == BinaryOp::AND )
-    return _mm256_and_si256( vr, v2 );
-  else if constexpr ( binary_op == BinaryOp::OR )
-    return _mm256_or_si256( vr, v2 );
-  else if constexpr ( binary_op == BinaryOp::XOR )
-    return _mm256_xor_si256( vr, v2 );
-  else if constexpr ( binary_op == BinaryOp::LT )
-    return _mm256_andnot_si256( vr, v2 );
-  else
-    static_assert( binary_op != binary_op, "Unsupported BinaryOp" );
+  if constexpr ( Op == BinaryOp::AND )
+    return []( __m256i a, __m256i b )
+    { return _mm256_and_si256( a, b ); };
+  else if constexpr ( Op == BinaryOp::OR )
+    return []( __m256i a, __m256i b )
+    { return _mm256_or_si256( a, b ); };
+  else if constexpr ( Op == BinaryOp::XOR )
+    return []( __m256i a, __m256i b )
+    { return _mm256_xor_si256( a, b ); };
+  else if constexpr ( Op == BinaryOp::LT )
+    return []( __m256i a, __m256i b )
+    { return _mm256_andnot_si256( a, b ); };
 }
 #endif
 
-/*! Perform the vectorized version of the binary operations using AVX2. */
-template<BinaryOp binary_op, typename TT, typename ScalarOp>
-inline TT bitwise_binop( const TT& tta, const TT& ttb, ScalarOp&& scalar_op )
+/*! Compile-time dispatch of the scalar operations. */
+template<BinaryOp Op, typename T>
+constexpr auto scalar_operation()
+{
+  if constexpr ( Op == BinaryOp::AND )
+    return std::bit_and<T>{};
+  else if constexpr ( Op == BinaryOp::OR )
+    return std::bit_or<T>{};
+  else if constexpr ( Op == BinaryOp::XOR )
+    return std::bit_xor<T>{};
+  else if constexpr ( Op == BinaryOp::LT )
+    return []( T a, T b )
+    { return ~a & b; };
+}
+
+/*! \brief Universal function for vectorized operations between two truth tables.
+ *
+ * Computes the bitwise operation \f$tt_a Op tt_b\f$ using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficient
+ * parallel computation across the truth tables. When the number of bits is not
+ * a multiple of four, the function fallsback to the scalar version on the tailing
+ * words.
+ *
+ * \tparam Op Binary operation.
+ * \tparam TT Truth table type.
+ * \param tta First truth table.
+ * \param ttb Second truth table.
+ * \return The truth table obtained by applying Op.
+ */
+template<BinaryOp Op, typename TT>
+inline TT binary_operation( const TT& tta, const TT& ttb )
 {
   TT result = tta;
   size_t size = tta.num_blocks();
   auto& datar = result._bits;
   const auto& data2 = ttb._bits;
+  using T = typename std::decay_t<decltype( datar[0] )>;
 
   size_t i = 0;
 #if KITTY_HAS_AVX2
   if ( has_avx2_cached() && size >= 4 )
   {
-    for ( ; i + 4 <= size; i += 4 )
+    auto binary_op = vector_operation<Op>();
+    for ( ; i + 3 < size; i += 4 )
     {
       __m256i vr = _mm256_loadu_si256( reinterpret_cast<const __m256i*>( &datar[i] ) );
       __m256i v2 = _mm256_loadu_si256( reinterpret_cast<const __m256i*>( &data2[i] ) );
-      vr = get_simd_op<binary_op>( vr, v2 );
+      vr = binary_op( vr, v2 );
       _mm256_storeu_si256( reinterpret_cast<__m256i*>( &datar[i] ), vr );
     }
   }
 #endif
-  /* Fallback to the scalar version for the remaining elements. */
-  for ( ; i < size; ++i )
-  {
-    datar[i] = scalar_op( datar[i], data2[i] );
-  }
+  /* Fallback to the scalar version for the remaining words. */
+  auto scalar_op = scalar_operation<Op, T>();
+  std::transform( datar.cbegin() + i, datar.cend(), data2.cbegin() + i, datar.begin() + i, scalar_op );
 
   result.mask_bits();
   return result;
@@ -162,16 +193,15 @@ inline TT bitwise_binop( const TT& tta, const TT& ttb, ScalarOp&& scalar_op )
  * Each register processes four 64-bit words in parallel, enabling efficient
  * parallel computation across the truth tables.
  *
+ * \tparam TT Truth table type.
  * \param tta First truth table.
  * \param ttb Second truth table.
+ * \return The truth table obtained by applying the binary AND.
  */
 template<typename TT>
 inline TT bitwise_and( const TT& tta, const TT& ttb )
 {
-  return bitwise_binop<BinaryOp::AND>(
-      tta, ttb,
-      []( uint64_t a, uint64_t b )
-      { return a & b; } );
+  return binary_operation<BinaryOp::AND>( tta, ttb );
 }
 
 /*! \brief Perform a vectorized bitwise OR between two truth tables.
@@ -180,16 +210,15 @@ inline TT bitwise_and( const TT& tta, const TT& ttb )
  * Each register processes four 64-bit words in parallel, enabling efficient
  * parallel computation across the truth tables.
  *
+ * \tparam TT Truth table type.
  * \param tta First truth table.
  * \param ttb Second truth table.
+ * \return The truth table obtained by applying the binary OR.
  */
 template<typename TT>
 inline TT bitwise_or( const TT& tta, const TT& ttb )
 {
-  return bitwise_binop<BinaryOp::OR>(
-      tta, ttb,
-      []( uint64_t a, uint64_t b )
-      { return a | b; } );
+  return binary_operation<BinaryOp::OR>( tta, ttb );
 }
 
 /*! \brief Perform a vectorized bitwise XOR between two truth tables.
@@ -198,16 +227,15 @@ inline TT bitwise_or( const TT& tta, const TT& ttb )
  * Each register processes four 64-bit words in parallel, enabling efficient
  * parallel computation across the truth tables.
  *
+ * \tparam TT Truth table type.
  * \param tta First truth table.
  * \param ttb Second truth table.
+ * \return The truth table obtained by applying the binary XOR.
  */
 template<typename TT>
 inline TT bitwise_xor( const TT& tta, const TT& ttb )
 {
-  return bitwise_binop<BinaryOp::XOR>(
-      tta, ttb,
-      []( uint64_t a, uint64_t b )
-      { return a ^ b; } );
+  return binary_operation<BinaryOp::XOR>( tta, ttb );
 }
 
 /*! \brief Perform a vectorized bitwise LT ( Lower Than ) between two truth tables.
@@ -216,16 +244,15 @@ inline TT bitwise_xor( const TT& tta, const TT& ttb )
  * Each register processes four 64-bit words in parallel, enabling efficient
  * parallel computation across the truth tables.
  *
+ * \tparam TT Truth table type.
  * \param tta First truth table.
  * \param ttb Second truth table.
+ * \return The truth table obtained by applying the binary LT.
  */
 template<typename TT>
 inline TT bitwise_lt( const TT& tta, const TT& ttb )
 {
-  return bitwise_binop<BinaryOp::LT>(
-      tta, ttb,
-      []( uint64_t a, uint64_t b )
-      { return ~a & b; } );
+  return binary_operation<BinaryOp::LT>( tta, ttb );
 }
 
 /*! \brief Perform a vectorized inversion of a truth tables.
@@ -234,7 +261,9 @@ inline TT bitwise_lt( const TT& tta, const TT& ttb )
  * Each register processes four 64-bit words in parallel, enabling efficient
  * parallel inversion across the truth tables.
  *
+ * \tparam TT Truth table type.
  * \param tt Truth table.
+ * \return The negated truth table.
  */
 template<typename TT>
 inline TT unary_not( const TT& tt )
@@ -248,7 +277,7 @@ inline TT unary_not( const TT& tt )
   if ( has_avx2_cached() )
   {
     const __m256i all_ones = _mm256_set1_epi64x( -1 );
-    for ( ; i + 4 <= size; i += 4 )
+    for ( ; i + 3 < size; i += 4 )
     {
       __m256i v = _mm256_loadu_si256( reinterpret_cast<const __m256i*>( &data[i] ) );
       v = _mm256_xor_si256( v, all_ones );
@@ -257,16 +286,23 @@ inline TT unary_not( const TT& tt )
   }
 #endif
 
-  for ( ; i < size; ++i )
-  {
-    data[i] = ~data[i];
-  }
+  std::transform( data.cbegin() + i, data.cend(), result.begin() + i, std::bit_not<>() );
+
   result.mask_bits();
   return result;
 }
 
-/*! Vectorized set of a truth-table to a constant value. */
-template<typename TT, uint32_t VAL>
+/*! \brief Vectorized set of a truth-table to a constant value.
+ *
+ * Assign the bits of a truth table to a constant using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficient
+ * parallel assignment across the truth tables.
+ *
+ * \tparam TT Truth table type.
+ * \tparam Const Constant value to be assigned ( 0 for contradiction, anything for tautology ).
+ * \param tt Truth table.
+ */
+template<typename TT, uint32_t Const>
 inline void set_const( TT& tt )
 {
   size_t size = tt.num_blocks();
@@ -277,16 +313,16 @@ inline void set_const( TT& tt )
   if ( has_avx2_cached() )
   {
     __m256i v;
-    if constexpr ( VAL == 0 )
+    if constexpr ( Const == 0 )
     {
-      v = _mm256_setzero_si256(); // Set the vector to zero
+      v = _mm256_setzero_si256();
     }
     else
     {
       v = _mm256_set1_epi64x( -1 );
     }
 
-    for ( ; i + 4 <= size; i += 4 )
+    for ( ; i + 3 < size; i += 4 )
     {
       _mm256_storeu_si256( reinterpret_cast<__m256i*>( &data[i] ), v );
     }
@@ -294,7 +330,7 @@ inline void set_const( TT& tt )
 #endif
   uint64_t v;
 
-  if constexpr ( VAL == 0 )
+  if constexpr ( Const == 0 )
   {
     v = 0;
   }
@@ -304,10 +340,7 @@ inline void set_const( TT& tt )
   }
 
   // Handle remaining elements
-  for ( ; i < size; ++i )
-  {
-    data[i] = v;
-  }
+  std::fill( data.begin() + i, data.end(), v );
 }
 
 /*! \brief Reset all the bits of a truth table to 0 through vectorization.
@@ -316,6 +349,7 @@ inline void set_const( TT& tt )
  * Each register processes four 64-bit words in parallel, enabling efficiently
  * setting the truth table to the desird value.
  *
+ * \tparam TT Truth table type.
  * \param tt Truth table.
  */
 template<typename TT>
@@ -330,6 +364,7 @@ inline void set_zero( TT& tt )
  * Each register processes four 64-bit words in parallel, enabling efficiently
  * setting the truth table to the desird value.
  *
+ * \tparam TT truth table type.
  * \param tt Truth table.
  */
 template<typename TT>
@@ -338,35 +373,35 @@ inline void set_ones( TT& tt )
   set_const<TT, 1>( tt );
 }
 
-/*! Implementation of unary NOT for small static truth tables for compatibility. */
+/*! Fallback to the default unary NOT for small static truth tables. */
 template<uint32_t NumVars>
 inline kitty::static_truth_table<NumVars> unary_not( kitty::static_truth_table<NumVars, true> const& tt )
 {
   return ~tt;
 }
 
-/*! Implementation of bitwise AND for small static truth tables for compatibility. */
+/*! Fallback to the default bitwise AND for small static truth tables. */
 template<uint32_t NumVars>
 inline kitty::static_truth_table<NumVars> bitwise_and( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
 {
   return tta & ttb;
 }
 
-/*! Implementation of bitwise OR for small static truth tables for compatibility. */
+/*! Fallback to the default bitwise OR for small static truth tables. */
 template<uint32_t NumVars>
 inline kitty::static_truth_table<NumVars> bitwise_or( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
 {
   return tta | ttb;
 }
 
-/*! Implementation of bitwise XOR for small static truth tables for compatibility. */
+/*! Fallback to the default bitwise XOR for small static truth tables. */
 template<uint32_t NumVars>
 inline kitty::static_truth_table<NumVars> bitwise_xor( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
 {
   return tta ^ ttb;
 }
 
-/*! Implementation of bitwise LT for small static truth tables for compatibility. */
+/*! Fallback to the default bitwise LT for small static truth tables. */
 template<uint32_t NumVars>
 inline kitty::static_truth_table<NumVars> bitwise_lt( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
 {

--- a/include/kitty/simd_operations.hpp
+++ b/include/kitty/simd_operations.hpp
@@ -1,0 +1,392 @@
+/* kitty: C++ truth table library
+ * Copyright (C) 2017-2022  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file simd_operations.hpp
+  \brief Implements efficient alternatives of some common operations using SIMD
+
+  \author Andrea Costamagna
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <cassert>
+#include <numeric>
+#include <algorithm>
+
+#include "static_truth_table.hpp"
+#include "partial_truth_table.hpp"
+#include "dynamic_truth_table.hpp"
+#include "detail/mscfix.hpp"
+
+/*! Check if the code is compiled on a platform that might support AVX2 */
+#ifndef KITTY_HAS_AVX2
+#if defined( __x86_64__ ) || defined( _M_X64 ) || defined( _MSC_VER )
+#define KITTY_HAS_AVX2 1
+#else
+#define KITTY_HAS_AVX2 0
+#endif
+#endif
+
+#if KITTY_HAS_AVX2
+#if defined( _MSC_VER )
+#include <intrin.h>
+#else
+#include <immintrin.h>
+#include <cpuid.h>
+#endif
+#endif
+
+namespace kitty
+{
+
+namespace simd
+{
+/*! Check if AVX2 is supported on this machine. */
+inline bool has_avx2_cached()
+{
+#if KITTY_HAS_AVX2
+#if defined( _MSC_VER )
+  static const bool cached = []
+  {
+    int cpuInfo[4];
+    __cpuid( cpuInfo, 0 );
+    if ( cpuInfo[0] < 7 )
+      return false;
+    __cpuidex( cpuInfo, 7, 0 );
+    return ( cpuInfo[1] & ( 1 << 5 ) ) != 0;
+  }();
+  return cached;
+#else
+  static const bool cached = []
+  {
+    unsigned int eax, ebx, ecx, edx;
+    unsigned int max_leaf = __get_cpuid_max( 0, nullptr );
+    if ( !max_leaf || max_leaf < 7 )
+      return false;
+    __cpuid_count( 7, 0, eax, ebx, ecx, edx );
+    return ( ebx & ( 1 << 5 ) ) != 0;
+  }();
+  return cached;
+#endif
+#else
+  return false;
+#endif
+}
+
+/*! Enumeration type to minimize code redundancies. */
+enum class BinaryOp
+{
+  AND,
+  OR,
+  XOR,
+  LT
+};
+
+/*! Compile-time dispatch of the binary operations. */
+#if KITTY_HAS_AVX2
+template<BinaryOp binary_op>
+inline __m256i get_simd_op( __m256i vr, __m256i v2 )
+{
+  if constexpr ( binary_op == BinaryOp::AND )
+    return _mm256_and_si256( vr, v2 );
+  else if constexpr ( binary_op == BinaryOp::OR )
+    return _mm256_or_si256( vr, v2 );
+  else if constexpr ( binary_op == BinaryOp::XOR )
+    return _mm256_xor_si256( vr, v2 );
+  else if constexpr ( binary_op == BinaryOp::LT )
+    return _mm256_andnot_si256( vr, v2 );
+  else
+    static_assert( binary_op != binary_op, "Unsupported BinaryOp" );
+}
+#endif
+
+/*! Perform the vectorized version of the binary operations using AVX2. */
+template<BinaryOp binary_op, typename TT, typename ScalarOp>
+inline TT bitwise_binop( const TT& tta, const TT& ttb, ScalarOp&& scalar_op )
+{
+  TT result = tta;
+  size_t size = tta.num_blocks();
+  auto& datar = result._bits;
+  const auto& data2 = ttb._bits;
+
+  size_t i = 0;
+#if KITTY_HAS_AVX2
+  if ( has_avx2_cached() && size >= 4 )
+  {
+    for ( ; i + 4 <= size; i += 4 )
+    {
+      __m256i vr = _mm256_loadu_si256( reinterpret_cast<const __m256i*>( &datar[i] ) );
+      __m256i v2 = _mm256_loadu_si256( reinterpret_cast<const __m256i*>( &data2[i] ) );
+      vr = get_simd_op<binary_op>( vr, v2 );
+      _mm256_storeu_si256( reinterpret_cast<__m256i*>( &datar[i] ), vr );
+    }
+  }
+#endif
+  /* Fallback to the scalar version for the remaining elements. */
+  for ( ; i < size; ++i )
+  {
+    datar[i] = scalar_op( datar[i], data2[i] );
+  }
+
+  result.mask_bits();
+  return result;
+}
+
+/*! \brief Perform a vectorized bitwise AND between two truth tables.
+ *
+ * Computes the bitwise AND \f$tt_a \land tt_b\f$ using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficient
+ * parallel computation across the truth tables.
+ *
+ * \param tta First truth table.
+ * \param ttb Second truth table.
+ */
+template<typename TT>
+inline TT bitwise_and( const TT& tta, const TT& ttb )
+{
+  return bitwise_binop<BinaryOp::AND>(
+      tta, ttb,
+      []( uint64_t a, uint64_t b )
+      { return a & b; } );
+}
+
+/*! \brief Perform a vectorized bitwise OR between two truth tables.
+ *
+ * Computes the bitwise OR \f$tt_a \lor tt_b\f$ using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficient
+ * parallel computation across the truth tables.
+ *
+ * \param tta First truth table.
+ * \param ttb Second truth table.
+ */
+template<typename TT>
+inline TT bitwise_or( const TT& tta, const TT& ttb )
+{
+  return bitwise_binop<BinaryOp::OR>(
+      tta, ttb,
+      []( uint64_t a, uint64_t b )
+      { return a | b; } );
+}
+
+/*! \brief Perform a vectorized bitwise XOR between two truth tables.
+ *
+ * Computes the bitwise XOR \f$tt_a \lxor tt_b\f$ using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficient
+ * parallel computation across the truth tables.
+ *
+ * \param tta First truth table.
+ * \param ttb Second truth table.
+ */
+template<typename TT>
+inline TT bitwise_xor( const TT& tta, const TT& ttb )
+{
+  return bitwise_binop<BinaryOp::XOR>(
+      tta, ttb,
+      []( uint64_t a, uint64_t b )
+      { return a ^ b; } );
+}
+
+/*! \brief Perform a vectorized bitwise LT ( Lower Than ) between two truth tables.
+ *
+ * Computes the bitwise LT \f$ ~tt_a \land tt_b\f$ using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficient
+ * parallel computation across the truth tables.
+ *
+ * \param tta First truth table.
+ * \param ttb Second truth table.
+ */
+template<typename TT>
+inline TT bitwise_lt( const TT& tta, const TT& ttb )
+{
+  return bitwise_binop<BinaryOp::LT>(
+      tta, ttb,
+      []( uint64_t a, uint64_t b )
+      { return ~a & b; } );
+}
+
+/*! \brief Perform a vectorized inversion of a truth tables.
+ *
+ * Computes the inverse \f$ ~tt \f$ using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficient
+ * parallel inversion across the truth tables.
+ *
+ * \param tt Truth table.
+ */
+template<typename TT>
+inline TT unary_not( const TT& tt )
+{
+  TT result = tt;
+  size_t size = tt.num_blocks();
+  auto& data = result._bits;
+
+  size_t i = 0;
+#if KITTY_HAS_AVX2
+  if ( has_avx2_cached() )
+  {
+    const __m256i all_ones = _mm256_set1_epi64x( -1 );
+    for ( ; i + 4 <= size; i += 4 )
+    {
+      __m256i v = _mm256_loadu_si256( reinterpret_cast<const __m256i*>( &data[i] ) );
+      v = _mm256_xor_si256( v, all_ones );
+      _mm256_storeu_si256( reinterpret_cast<__m256i*>( &data[i] ), v );
+    }
+  }
+#endif
+
+  for ( ; i < size; ++i )
+  {
+    data[i] = ~data[i];
+  }
+  result.mask_bits();
+  return result;
+}
+
+/*! Vectorized set of a truth-table to a constant value. */
+template<typename TT, uint32_t VAL>
+inline void set_const( TT& tt )
+{
+  size_t size = tt.num_blocks();
+  auto& data = tt._bits;
+
+  size_t i = 0;
+#if KITTY_HAS_AVX2
+  if ( has_avx2_cached() )
+  {
+    __m256i v;
+    if constexpr ( VAL == 0 )
+    {
+      v = _mm256_setzero_si256(); // Set the vector to zero
+    }
+    else
+    {
+      v = _mm256_set1_epi64x( -1 );
+    }
+
+    for ( ; i + 4 <= size; i += 4 )
+    {
+      _mm256_storeu_si256( reinterpret_cast<__m256i*>( &data[i] ), v );
+    }
+  }
+#endif
+  uint64_t v;
+
+  if constexpr ( VAL == 0 )
+  {
+    v = 0;
+  }
+  else
+  {
+    v = (uint64_t)( -1 );
+  }
+
+  // Handle remaining elements
+  for ( ; i < size; ++i )
+  {
+    data[i] = v;
+  }
+}
+
+/*! \brief Reset all the bits of a truth table to 0 through vectorization.
+ *
+ * Set all the bits of a truth table to 0 using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficiently
+ * setting the truth table to the desird value.
+ *
+ * \param tt Truth table.
+ */
+template<typename TT>
+inline void set_zero( TT& tt )
+{
+  set_const<TT, 0>( tt );
+}
+
+/*! \brief Reset all the bits of a truth table to 1 through vectorization.
+ *
+ * Set all the bits of a truth table to 1 using 256-bit AVX2 registers.
+ * Each register processes four 64-bit words in parallel, enabling efficiently
+ * setting the truth table to the desird value.
+ *
+ * \param tt Truth table.
+ */
+template<typename TT>
+inline void set_ones( TT& tt )
+{
+  set_const<TT, 1>( tt );
+}
+
+/*! Implementation of unary NOT for small static truth tables for compatibility. */
+template<uint32_t NumVars>
+inline kitty::static_truth_table<NumVars> unary_not( kitty::static_truth_table<NumVars, true> const& tt )
+{
+  return ~tt;
+}
+
+/*! Implementation of bitwise AND for small static truth tables for compatibility. */
+template<uint32_t NumVars>
+inline kitty::static_truth_table<NumVars> bitwise_and( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
+{
+  return tta & ttb;
+}
+
+/*! Implementation of bitwise OR for small static truth tables for compatibility. */
+template<uint32_t NumVars>
+inline kitty::static_truth_table<NumVars> bitwise_or( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
+{
+  return tta | ttb;
+}
+
+/*! Implementation of bitwise XOR for small static truth tables for compatibility. */
+template<uint32_t NumVars>
+inline kitty::static_truth_table<NumVars> bitwise_xor( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
+{
+  return tta ^ ttb;
+}
+
+/*! Implementation of bitwise LT for small static truth tables for compatibility. */
+template<uint32_t NumVars>
+inline kitty::static_truth_table<NumVars> bitwise_lt( const kitty::static_truth_table<NumVars, true>& tta, const kitty::static_truth_table<NumVars, true>& ttb )
+{
+  return ~tta & ttb;
+}
+
+/*! Implementation set to constant 1 for small static truth tables. */
+template<uint32_t NumVars>
+inline void set_ones( kitty::static_truth_table<NumVars, true>& tt )
+{
+  tt |= ~tt;
+}
+
+/*! Implementation set to constant 0 for small static truth tables. */
+template<uint32_t NumVars>
+inline void set_zero( kitty::static_truth_table<NumVars, true>& tt )
+{
+  tt ^= tt;
+}
+
+} // namespace simd
+
+} // namespace kitty

--- a/test/simd_operations.cpp
+++ b/test/simd_operations.cpp
@@ -62,7 +62,7 @@ protected:
 #if KITTY_HAS_AVX2
     if ( simd::has_avx2_cached() )
     {
-      EXPECT_LE( time_diff, -0.2 );
+      EXPECT_LE( time_diff, 0 );
     }
 #endif
   }
@@ -87,7 +87,7 @@ protected:
 #if KITTY_HAS_AVX2
     if ( simd::has_avx2_cached() )
     {
-      EXPECT_LE( time_diff, -0.1 );
+      EXPECT_LE( time_diff, 0 );
     }
 #endif
   }
@@ -113,7 +113,7 @@ protected:
 #if KITTY_HAS_AVX2
     if ( simd::has_avx2_cached() )
     {
-      EXPECT_LE( time_diff, -0.2 );
+      EXPECT_LE( time_diff, 0 );
     }
 #endif
   }
@@ -151,28 +151,10 @@ protected:
   }
 };
 
-TEST_F( SIMDTest, simd_unary_not_large )
-{
-  using TTS = static_truth_table<10>;
-  using TTD = dynamic_truth_table;
-
-  TTS tts;
-  test_unary( []( const TTS& t )
-              { return unary_not<TTS>( t ); },
-              []( const TTS& t )
-              { return simd::unary_not<TTS>( t ); },
-              tts );
-
-  TTD ttd( 12u );
-  test_unary( []( const TTD& t )
-              { return unary_not<TTD>( t ); },
-              []( const TTD& t )
-              { return simd::unary_not<TTD>( t ); },
-              ttd );
-}
-
 TEST_F( SIMDTest, simd_set_zero_large )
 {
+  simd::test_avx2_advantage();
+
   using TTS = static_truth_table<10>;
   using TTD = dynamic_truth_table;
   TTS tts;
@@ -191,6 +173,8 @@ TEST_F( SIMDTest, simd_set_zero_large )
 
 TEST_F( SIMDTest, simd_set_ones_large )
 {
+  simd::test_avx2_advantage();
+
   using TTS = static_truth_table<10>;
   using TTD = dynamic_truth_table;
   TTS tts;
@@ -209,6 +193,8 @@ TEST_F( SIMDTest, simd_set_ones_large )
 
 TEST_F( SIMDTest, simd_binary_and_large )
 {
+  simd::test_avx2_advantage();
+
   using TTS = static_truth_table<10>;
   using TTD = dynamic_truth_table;
   TTS tts;
@@ -227,6 +213,8 @@ TEST_F( SIMDTest, simd_binary_and_large )
 
 TEST_F( SIMDTest, simd_binary_xor_large )
 {
+  simd::test_avx2_advantage();
+
   using TTS = static_truth_table<10>;
   using TTD = dynamic_truth_table;
   TTS tts;
@@ -245,6 +233,8 @@ TEST_F( SIMDTest, simd_binary_xor_large )
 
 TEST_F( SIMDTest, simd_binary_or_large )
 {
+  simd::test_avx2_advantage();
+
   using TTS = static_truth_table<10>;
   using TTD = dynamic_truth_table;
   TTS tts;
@@ -263,6 +253,8 @@ TEST_F( SIMDTest, simd_binary_or_large )
 
 TEST_F( SIMDTest, simd_binary_lt_large )
 {
+  simd::test_avx2_advantage();
+
   using TTS = static_truth_table<10>;
   using TTD = dynamic_truth_table;
   TTS tts;

--- a/test/simd_operations.cpp
+++ b/test/simd_operations.cpp
@@ -155,7 +155,7 @@ TEST_F( SIMDTest, simd_set_zero_large )
 {
   simd::test_avx2_advantage();
 
-  using TTS = static_truth_table<10>;
+  using TTS = static_truth_table<12>;
   using TTD = dynamic_truth_table;
   TTS tts;
   test_noreturn( [&]( TTS& t )
@@ -175,7 +175,7 @@ TEST_F( SIMDTest, simd_set_ones_large )
 {
   simd::test_avx2_advantage();
 
-  using TTS = static_truth_table<10>;
+  using TTS = static_truth_table<12>;
   using TTD = dynamic_truth_table;
   TTS tts;
   test_noreturn( [&]( TTS& t )
@@ -195,7 +195,7 @@ TEST_F( SIMDTest, simd_binary_and_large )
 {
   simd::test_avx2_advantage();
 
-  using TTS = static_truth_table<10>;
+  using TTS = static_truth_table<12>;
   using TTD = dynamic_truth_table;
   TTS tts;
   test_binary( []( const TTS& t1, const TTS& t2 )
@@ -215,7 +215,7 @@ TEST_F( SIMDTest, simd_binary_xor_large )
 {
   simd::test_avx2_advantage();
 
-  using TTS = static_truth_table<10>;
+  using TTS = static_truth_table<12>;
   using TTD = dynamic_truth_table;
   TTS tts;
   test_binary( []( const TTS& t1, const TTS& t2 )
@@ -235,7 +235,7 @@ TEST_F( SIMDTest, simd_binary_or_large )
 {
   simd::test_avx2_advantage();
 
-  using TTS = static_truth_table<10>;
+  using TTS = static_truth_table<12>;
   using TTD = dynamic_truth_table;
   TTS tts;
   test_binary( []( const TTS& t1, const TTS& t2 )
@@ -255,7 +255,7 @@ TEST_F( SIMDTest, simd_binary_lt_large )
 {
   simd::test_avx2_advantage();
 
-  using TTS = static_truth_table<10>;
+  using TTS = static_truth_table<12>;
   using TTD = dynamic_truth_table;
   TTS tts;
   test_binary( []( const TTS& t1, const TTS& t2 )

--- a/test/simd_operations.cpp
+++ b/test/simd_operations.cpp
@@ -111,10 +111,9 @@ protected:
       time_diff += ( time_simd - time_sisd ) / time_sisd / static_cast<double>( num_cases );
     }
 #if KITTY_HAS_AVX2 && !defined( _MSC_VER )
-    if ( simd::has_avx2_cached() && simd::use_avx2_cached<Op, TT>( tt, tt.num_vars() ) && !)
+    if ( simd::has_avx2_cached() && simd::use_avx2_cached<Op, TT>( tt, tt.num_vars() ) )
     {
       EXPECT_LE( time_diff, 0 );
-      std::cout << "time diff: " << time_diff << std::endl;
     }
 #endif
   }

--- a/test/simd_operations.cpp
+++ b/test/simd_operations.cpp
@@ -1,0 +1,278 @@
+/* kitty: C++ truth table library
+ * Copyright (C) 2017-2020  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include <kitty/bit_operations.hpp>
+#include <kitty/dynamic_truth_table.hpp>
+#include <kitty/simd_operations.hpp>
+#include <kitty/static_truth_table.hpp>
+
+#include "utility.hpp"
+
+using namespace kitty;
+
+class SIMDTest : public kitty::testing::Test
+{
+protected:
+  template<typename FnSisd, typename FnSimd, typename TT>
+  void test_noreturn( FnSisd fn_sisd, FnSimd fn_simd, TT& tt ) const
+  {
+    TT tt1 = tt.construct();
+    TT tt2 = tt.construct();
+    double time_diff = 0;
+    double time_sisd = 0;
+    double time_simd = 0;
+    for ( auto i = 0u; i < 20u; ++i )
+    {
+      create_random( tt1 );
+      tt2 = tt1;
+
+      run_noreturn_with_time<FnSisd, TT>( fn_sisd, tt1, time_sisd );
+      run_noreturn_with_time<FnSimd, TT>( fn_simd, tt2, time_simd );
+
+      time_diff += ( time_simd - time_sisd ) / time_sisd;
+    }
+#if KITTY_HAS_AVX2
+    if ( simd::has_avx2_cached() )
+    {
+      EXPECT_LE( time_diff, 0 );
+    }
+#endif
+  }
+
+  template<typename FnSisd, typename FnSimd, typename TT>
+  void test_unary( FnSisd fn_sisd, FnSimd fn_simd, TT tt ) const
+  {
+    double time_diff = 0;
+    double time_sisd = 0;
+    double time_simd = 0;
+    TT tt1 = tt.construct();
+    for ( auto i = 0u; i < 20u; ++i )
+    {
+      create_random( tt1 );
+
+      auto res_sisd = run_with_time<FnSisd, TT>( fn_sisd, tt1, time_sisd );
+      auto res_simd = run_with_time<FnSimd, TT>( fn_simd, tt1, time_simd );
+      EXPECT_EQ( res_simd, res_sisd );
+
+      time_diff += ( time_simd - time_sisd ) / time_sisd;
+    }
+#if KITTY_HAS_AVX2
+    if ( simd::has_avx2_cached() )
+    {
+      EXPECT_LE( time_diff, 0 );
+    }
+#endif
+  }
+
+  template<typename FnSisd, typename FnSimd, typename TT>
+  void test_binary( FnSisd fn_sisd, FnSimd fn_simd, TT tt ) const
+  {
+    double time_diff = 0;
+    double time_sisd = 0;
+    double time_simd = 0;
+    TT tt1 = tt.construct();
+    TT tt2 = tt.construct();
+    for ( auto i = 0u; i < 20u; ++i )
+    {
+      create_random( tt1 );
+
+      auto res_sisd = run_with_time<FnSisd, TT>( fn_sisd, tt1, tt2, time_sisd );
+      auto res_simd = run_with_time<FnSimd, TT>( fn_simd, tt1, tt2, time_simd );
+      EXPECT_EQ( res_simd, res_sisd );
+
+      time_diff += ( time_simd - time_sisd ) / time_sisd;
+    }
+#if KITTY_HAS_AVX2
+    if ( simd::has_avx2_cached() )
+    {
+      EXPECT_LE( time_diff, 0 );
+    }
+#endif
+  }
+
+  template<typename F, typename TT>
+  auto run_with_time( F func, TT& tt, double& t ) const
+  {
+    auto start = std::chrono::high_resolution_clock::now();
+    auto const res = func( tt );
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
+    t = elapsed.count();
+    return res;
+  }
+
+  template<typename F, typename TT>
+  auto run_with_time( F func, TT& tt1, TT& tt2, double& t ) const
+  {
+    auto start = std::chrono::high_resolution_clock::now();
+    auto const res = func( tt1, tt2 );
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
+    t = elapsed.count();
+    return res;
+  }
+
+  template<typename F, typename TT>
+  void run_noreturn_with_time( F func, TT& tt, double& t ) const
+  {
+    auto start = std::chrono::high_resolution_clock::now();
+    func( tt );
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
+    t = elapsed.count();
+  }
+};
+
+TEST_F( SIMDTest, simd_unary_not_large )
+{
+  using TTS = static_truth_table<10>;
+  using TTD = dynamic_truth_table;
+
+  TTS tts;
+  test_unary( []( const TTS& t )
+              { return unary_not<TTS>( t ); },
+              []( const TTS& t )
+              { return simd::unary_not<TTS>( t ); },
+              tts );
+
+  TTD ttd( 12u );
+  test_unary( []( const TTD& t )
+              { return unary_not<TTD>( t ); },
+              []( const TTD& t )
+              { return simd::unary_not<TTD>( t ); },
+              ttd );
+}
+
+TEST_F( SIMDTest, simd_set_zero_large )
+{
+  using TTS = static_truth_table<10>;
+  using TTD = dynamic_truth_table;
+  TTS tts;
+  test_noreturn( [&]( TTS& t )
+                 { t = t ^ t; },
+                 [&]( TTS& t )
+                 { simd::set_zero<TTS>( t ); },
+                 tts );
+  TTD ttd( 12u );
+  test_noreturn( [&]( TTD& t )
+                 { t = t ^ t; },
+                 [&]( TTD& t )
+                 { simd::set_zero<TTD>( t ); },
+                 ttd );
+}
+
+TEST_F( SIMDTest, simd_set_ones_large )
+{
+  using TTS = static_truth_table<10>;
+  using TTD = dynamic_truth_table;
+  TTS tts;
+  test_noreturn( [&]( TTS& t )
+                 { t = t ^ ~t; },
+                 [&]( TTS& t )
+                 { simd::set_ones<TTS>( t ); },
+                 tts );
+  TTD ttd;
+  test_noreturn( [&]( TTD& t )
+                 { t = t ^ ~t; },
+                 [&]( TTD& t )
+                 { simd::set_ones<TTD>( t ); },
+                 ttd );
+}
+
+TEST_F( SIMDTest, simd_binary_and_large )
+{
+  using TTS = static_truth_table<10>;
+  using TTD = dynamic_truth_table;
+  TTS tts;
+  test_binary( []( const TTS& t1, const TTS& t2 )
+               { return t1 & t2; },
+               []( const TTS& t1, const TTS& t2 )
+               { return simd::bitwise_and<TTS>( t1, t2 ); },
+               tts );
+  TTD ttd( 12u );
+  test_binary( []( const TTD& t1, const TTD& t2 )
+               { return t1 & t2; },
+               []( const TTD& t1, const TTD& t2 )
+               { return simd::bitwise_and<TTD>( t1, t2 ); },
+               ttd );
+}
+
+TEST_F( SIMDTest, simd_binary_xor_large )
+{
+  using TTS = static_truth_table<10>;
+  using TTD = dynamic_truth_table;
+  TTS tts;
+  test_binary( []( const TTS& t1, const TTS& t2 )
+               { return t1 ^ t2; },
+               []( const TTS& t1, const TTS& t2 )
+               { return simd::bitwise_xor<TTS>( t1, t2 ); },
+               tts );
+  TTD ttd( 12u );
+  test_binary( []( const TTD& t1, const TTD& t2 )
+               { return t1 ^ t2; },
+               []( const TTD& t1, const TTD& t2 )
+               { return simd::bitwise_xor<TTD>( t1, t2 ); },
+               ttd );
+}
+
+TEST_F( SIMDTest, simd_binary_or_large )
+{
+  using TTS = static_truth_table<10>;
+  using TTD = dynamic_truth_table;
+  TTS tts;
+  test_binary( []( const TTS& t1, const TTS& t2 )
+               { return t1 | t2; },
+               []( const TTS& t1, const TTS& t2 )
+               { return simd::bitwise_or<TTS>( t1, t2 ); },
+               tts );
+  TTD ttd( 12u );
+  test_binary( []( const TTD& t1, const TTD& t2 )
+               { return t1 | t2; },
+               []( const TTD& t1, const TTD& t2 )
+               { return simd::bitwise_or<TTD>( t1, t2 ); },
+               ttd );
+}
+
+TEST_F( SIMDTest, simd_binary_lt_large )
+{
+  using TTS = static_truth_table<10>;
+  using TTD = dynamic_truth_table;
+  TTS tts;
+  test_binary( []( const TTS& t1, const TTS& t2 )
+               { return ~t1 & t2; },
+               []( const TTS& t1, const TTS& t2 )
+               { return simd::bitwise_lt<TTS>( t1, t2 ); },
+               tts );
+  TTD ttd( 12u );
+  test_binary( []( const TTD& t1, const TTD& t2 )
+               { return ~t1 & t2; },
+               []( const TTD& t1, const TTD& t2 )
+               { return simd::bitwise_lt<TTD>( t1, t2 ); },
+               ttd );
+}

--- a/test/simd_operations.cpp
+++ b/test/simd_operations.cpp
@@ -38,6 +38,8 @@ using namespace kitty;
 
 class SIMDTest : public kitty::testing::Test
 {
+  static constexpr auto num_cases = 20u;
+
 protected:
   template<typename FnSisd, typename FnSimd, typename TT>
   void test_noreturn( FnSisd fn_sisd, FnSimd fn_simd, TT& tt ) const
@@ -47,7 +49,7 @@ protected:
     double time_diff = 0;
     double time_sisd = 0;
     double time_simd = 0;
-    for ( auto i = 0u; i < 20u; ++i )
+    for ( auto i = 0u; i < num_cases; ++i )
     {
       create_random( tt1 );
       tt2 = tt1;
@@ -55,12 +57,12 @@ protected:
       run_noreturn_with_time<FnSisd, TT>( fn_sisd, tt1, time_sisd );
       run_noreturn_with_time<FnSimd, TT>( fn_simd, tt2, time_simd );
 
-      time_diff += ( time_simd - time_sisd ) / time_sisd;
+      time_diff += ( time_simd - time_sisd ) / time_sisd / static_cast<double>( num_cases );
     }
 #if KITTY_HAS_AVX2
     if ( simd::has_avx2_cached() )
     {
-      EXPECT_LE( time_diff, 0 );
+      EXPECT_LE( time_diff, -0.2 );
     }
 #endif
   }
@@ -72,7 +74,7 @@ protected:
     double time_sisd = 0;
     double time_simd = 0;
     TT tt1 = tt.construct();
-    for ( auto i = 0u; i < 20u; ++i )
+    for ( auto i = 0u; i < num_cases; ++i )
     {
       create_random( tt1 );
 
@@ -80,12 +82,12 @@ protected:
       auto res_simd = run_with_time<FnSimd, TT>( fn_simd, tt1, time_simd );
       EXPECT_EQ( res_simd, res_sisd );
 
-      time_diff += ( time_simd - time_sisd ) / time_sisd;
+      time_diff += ( time_simd - time_sisd ) / time_sisd / static_cast<double>( num_cases );
     }
 #if KITTY_HAS_AVX2
     if ( simd::has_avx2_cached() )
     {
-      EXPECT_LE( time_diff, 0 );
+      EXPECT_LE( time_diff, -0.1 );
     }
 #endif
   }
@@ -98,7 +100,7 @@ protected:
     double time_simd = 0;
     TT tt1 = tt.construct();
     TT tt2 = tt.construct();
-    for ( auto i = 0u; i < 20u; ++i )
+    for ( auto i = 0u; i < num_cases; ++i )
     {
       create_random( tt1 );
 
@@ -106,12 +108,12 @@ protected:
       auto res_simd = run_with_time<FnSimd, TT>( fn_simd, tt1, tt2, time_simd );
       EXPECT_EQ( res_simd, res_sisd );
 
-      time_diff += ( time_simd - time_sisd ) / time_sisd;
+      time_diff += ( time_simd - time_sisd ) / time_sisd / static_cast<double>( num_cases );
     }
 #if KITTY_HAS_AVX2
     if ( simd::has_avx2_cached() )
     {
-      EXPECT_LE( time_diff, 0 );
+      EXPECT_LE( time_diff, -0.2 );
     }
 #endif
   }


### PR DESCRIPTION
This PR introduces vectorized bitwise operations using 256-bit AVX2 registers. Each register processes four 64-bit words in parallel, enabling efficient computation across truth tables. These operations should be preferred over traditional scalar implementations for sufficiently large truth tables.

The optimal cutoff (in number of bits) at which AVX2 becomes advantageous may vary. Compiler-dependent benchmarking is required to identify this threshold. Tests show consistent speedups for 10-input static_truth_tables and 12-input dynamic_truth_tables.

**Acknowledgment**: Thanks to @Michal-Atlas for suggesting the use of Single Instruction, Multiple Data (SIMD) instructions to accelerate truth-table operations.

**Remark**: I also experimented with a pop-count implementation based on the AVX2 Harley–Seal algorithm described in “Faster Population Counts Using AVX2 Instructions” ([arXiv:1611.07612](https://arxiv.org/pdf/1611.07612)). However, on machines with sufficiently large L1 caches, the scalar version still outperforms it. A faster pop-count remains an open optimization target.