### PR TITLE
Constructor for projection functions for ternary truth tables

### DIFF
--- a/include/kitty/constructors.hpp
+++ b/include/kitty/constructors.hpp
@@ -158,6 +158,15 @@ void create_nth_var( static_truth_table<NumVars, true>& tt, uint8_t var_index, b
   /* mask if truth table does not require all bits */
   tt.mask_bits();
 }
+
+template<uint32_t NumVars>
+void create_nth_var( ternary_truth_table<static_truth_table<NumVars, true>>& tt, uint8_t var_index, bool complement = false )
+{
+  create_nth_var( tt._bits, var_index, complement );
+  tt._care = ~( tt._bits.construct() );
+  /* mask if truth table does not require all bits */
+  tt.mask_bits();
+}
 /*! \endcond */
 
 /*! \brief Constructs projections (single-variable functions) out-of-place

--- a/include/kitty/constructors.hpp
+++ b/include/kitty/constructors.hpp
@@ -46,8 +46,9 @@
 #include "dynamic_truth_table.hpp"
 #include "operations.hpp"
 #include "operators.hpp"
-#include "static_truth_table.hpp"
 #include "partial_truth_table.hpp"
+#include "static_truth_table.hpp"
+#include "ternary_truth_table.hpp"
 
 namespace kitty
 {

--- a/include/kitty/constructors.hpp
+++ b/include/kitty/constructors.hpp
@@ -159,8 +159,8 @@ void create_nth_var( static_truth_table<NumVars, true>& tt, uint8_t var_index, b
   tt.mask_bits();
 }
 
-template<uint32_t NumVars>
-void create_nth_var( ternary_truth_table<static_truth_table<NumVars, true>>& tt, uint8_t var_index, bool complement = false )
+template<typename TT>
+void create_nth_var( ternary_truth_table<TT>& tt, uint8_t var_index, bool complement = false )
 {
   create_nth_var( tt._bits, var_index, complement );
   tt._care = ~( tt._bits.construct() );

--- a/test/constructors.cpp
+++ b/test/constructors.cpp
@@ -31,6 +31,7 @@
 #include <kitty/constructors.hpp>
 #include <kitty/dynamic_truth_table.hpp>
 #include <kitty/static_truth_table.hpp>
+#include <kitty/ternary_truth_table.hpp>
 #include <kitty/partial_truth_table.hpp>
 
 using namespace kitty;
@@ -51,6 +52,7 @@ TEST( ConstructorsTest, create_nth_var5 )
 {
   static_truth_table<5> tt_s;
   dynamic_truth_table tt_d( 5 );
+  ternary_truth_table<static_truth_table<5>> tt_t;
 
   const auto mask = 0xffffffff;
 
@@ -60,6 +62,8 @@ TEST( ConstructorsTest, create_nth_var5 )
     EXPECT_EQ( tt_s._bits, detail::projections[i] & mask );
     create_nth_var( tt_d, i );
     EXPECT_EQ( tt_s._bits, tt_d._bits[0] );
+    create_nth_var( tt_t, i );
+    EXPECT_EQ( tt_t._bits, tt_s );
   }
 }
 

--- a/test/constructors.cpp
+++ b/test/constructors.cpp
@@ -67,6 +67,23 @@ TEST( ConstructorsTest, create_nth_var5 )
   }
 }
 
+TEST( ConstructorsTest, create_nth_var7 )
+{
+  static_truth_table<7> tt_s;
+  dynamic_truth_table tt_d( 7 );
+  ternary_truth_table<static_truth_table<7>> tt_t;
+
+  for ( auto i = 0; i <= 4; ++i )
+  {
+    create_nth_var( tt_s, i );
+    EXPECT_EQ( tt_s._bits[0], detail::projections[i] );
+    create_nth_var( tt_d, i );
+    EXPECT_EQ( tt_s._bits[0], tt_d._bits[0] );
+    create_nth_var( tt_t, i );
+    EXPECT_EQ( tt_t._bits, tt_s );
+  }
+}
+
 TEST( ConstructorsTest, create_from_binary_string )
 {
   static_truth_table<3> tt_s, tt_s_str;

--- a/test/constructors.cpp
+++ b/test/constructors.cpp
@@ -30,9 +30,9 @@
 
 #include <kitty/constructors.hpp>
 #include <kitty/dynamic_truth_table.hpp>
+#include <kitty/partial_truth_table.hpp>
 #include <kitty/static_truth_table.hpp>
 #include <kitty/ternary_truth_table.hpp>
-#include <kitty/partial_truth_table.hpp>
 
 using namespace kitty;
 


### PR DESCRIPTION
This PR addresses the limitation that `create_nth_var` did not previously support ternary truth tables. I added this functionality because ternary truth tables are well-suited for representing simulation patterns when synthesizing incompletely specified Boolean fuinctions, and the ability to construct corresponding projection functions is useful for initialization purposes.